### PR TITLE
Fix optimized dependency configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+## Unreleased
+
+### Bug fixes
+
+- Fixed optimized dependency configuration having invalid table keys in `Cargo.toml`.
+
+## Version 0.1.0
+
+The initial release!
+
+### Installation
+
+```cli
+cargo install cargo-bavy
+```
+
+### Usage
+
+Create a new Bevy app:
+
+```cli
+cargo bavy new <PROJECT_NAME>
+```
+
+It will ask you which features you want (asset hot reloading, fast linker, GitHub Action workflows, ...) and then creates a project template for you.

--- a/src/new/compile_features/dependencies.rs
+++ b/src/new/compile_features/dependencies.rs
@@ -17,13 +17,16 @@ fn set_cargo_toml_dependency_optimizations(folder_name: &str) {
 
     let mut profile = Table::new();
     profile.set_implicit(true);
-    let mut profile_dev = Table::new();
 
     // Enable a small amount of optimization in debug mode
     // ```toml
     // [profile.dev]
     // opt-level = 1
     // ```
+    let mut profile_dev = Table::new();
+    profile_dev
+        .decor_mut()
+        .set_prefix("\n# Enable a small amount of optimization in debug mode\n");
     profile_dev.insert("opt-level", value(1));
 
     let mut profile_dev_package = Table::new();
@@ -35,6 +38,9 @@ fn set_cargo_toml_dependency_optimizations(folder_name: &str) {
     // opt-level = 3
     // ```
     let mut profile_dev_package_all = Table::new();
+    profile_dev_package_all
+        .decor_mut()
+        .set_prefix("\n# Enable high optimizations for dependencies (incl. Bevy)\n");
     profile_dev_package_all["opt-level"] = value(3);
 
     profile_dev_package.insert("*", Item::Table(profile_dev_package_all));


### PR DESCRIPTION
Fixes #1.

Previously, the tables were added in a wrong way, so they looked like this:

```toml
["profile.dev"]
opt-level = 1

["profile.dev.package.\"*\""]
opt-level = 3
```

This PR fixes them to look like this:

```toml
# Enable a small amount of optimization in debug mode
[profile.dev]
opt-level = 1

# Enable high optimizations for dependencies (incl. Bevy)
[profile.dev.package."*"]
opt-level = 3
```

Now they are correctly recognized by Cargo and do not generate a warning anymore.