### PR TITLE
Fix shared generics flag being enabled on stable config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@
 ### Bug fixes
 
 - Fixed optimized dependency configuration having invalid table keys in `Cargo.toml`.
+- Fixed fast linker configuration including a shared generics flag on stable toolchain, which caused a compile error.
 
-## Version 0.1.0
+## Release v0.1.0 - 2022-08-19
 
 The initial release!
 

--- a/assets/.cargo/config.toml
+++ b/assets/.cargo/config.toml
@@ -5,19 +5,19 @@
 
 [target.x86_64-unknown-linux-gnu]
 linker = "clang"
-rustflags = ["-Clink-arg=-fuse-ld=lld"{{{share_generics}}}]
+rustflags = ["-Clink-arg=-fuse-ld=lld"{{{share_generics_yes}}}]
 
 # NOTE: you must manually install https://github.com/michaeleisel/zld on mac. you can easily do this with the "brew" package manager:
 # `brew install michaeleisel/zld/zld`
 [target.x86_64-apple-darwin]
-rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/zld"{{{share_generics}}}]
+rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/zld"{{{share_generics_yes}}}]
 
 [target.aarch64-apple-darwin]
-rustflags = ["-C", "link-arg=-fuse-ld=/opt/homebrew/bin/zld"{{{share_generics}}}]
+rustflags = ["-C", "link-arg=-fuse-ld=/opt/homebrew/bin/zld"{{{share_generics_yes}}}]
 
 [target.x86_64-pc-windows-msvc]
 linker = "rust-lld.exe"
-rustflags = ["-Zshare-generics=n"]
+rustflags = [{{{share_generics_no}}}]
 
 # Optional: Uncommenting the following improves compile times, but reduces the amount of debug info to 'line number tables only'
 # In most cases the gains are negligible, but if you are on macos and have slow compile times you should see significant gains.

--- a/src/new/compile_features/fast_linker.rs
+++ b/src/new/compile_features/fast_linker.rs
@@ -14,9 +14,13 @@ pub fn add_fast_linker(context: &mut Context) {
         .compile_features
         .contains(&CompileFeature::NightlyToolchain)
     {
-        config_toml = config_toml.replace("{{{share_generics}}}", r#", "-Zshare-generics=y""#);
+        config_toml = config_toml
+            .replace("{{{share_generics_yes}}}", r#", "-Zshare-generics=y""#)
+            .replace("{{{share_generics_no}}}", r#""-Zshare-generics=n""#);
     } else {
-        config_toml = config_toml.replace("{{{share_generics}}}", "");
+        config_toml = config_toml
+            .replace("{{{share_generics_yes}}}", "")
+            .replace("{{{share_generics_no}}}", "");
     }
 
     context


### PR DESCRIPTION
Fixes #10.

There was one shared generic flag left in the linker configuration with stable toolchain, this has now been fixed to only be included on nightly Rust.