### PR TITLE
Add `cargo bavy check` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 ### Enhancements
 
-- Added `cargo bavy build` and `cargo bavy run` commands:
+- Added `cargo bavy check`, `cargo bavy build` and `cargo bavy run` commands:
   - They work similar to `cargo` their counterpart.
   - They automatically add `--features bevy/dynamic` in debug mode for faster compile times.
   - They have an additional `--wasm`/`-w` flag to target the browser.
-  - All necessary tools can be installed for you.
+  - All necessary tools will be installed for you if needed.
 - A `.gitignore` file will now be added to the `wasm/` folder.
 
 ### Bug fixes

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -90,13 +90,28 @@ pub fn cargo_run(args: ArgBuilder) {
 
 /// Run `cargo build` with the given arguments.
 ///
-/// Exits the program if `cargo run` failed.
+/// Exits the program if `cargo build` failed.
 pub fn cargo_build(args: ArgBuilder) {
     let status = Command::new("cargo")
         .arg("build")
         .args(args.0)
         .status()
         .expect("Failed to run `cargo build`.");
+
+    if !status.success() {
+        exit(status.code().unwrap_or(1));
+    }
+}
+
+/// Run `cargo check` with the given arguments.
+///
+/// Exits the program if `cargo check` failed.
+pub fn cargo_check(args: ArgBuilder) {
+    let status = Command::new("cargo")
+        .arg("check")
+        .args(args.0)
+        .status()
+        .expect("Failed to run `cargo check`.");
 
     if !status.success() {
         exit(status.code().unwrap_or(1));

--- a/src/check/args.rs
+++ b/src/check/args.rs
@@ -1,0 +1,43 @@
+use crate::cargo::ArgBuilder;
+
+use super::cli::CheckCommand;
+
+impl From<&CheckCommand> for ArgBuilder {
+    fn from(cmd: &CheckCommand) -> Self {
+        let mut args = ArgBuilder::new();
+
+        let wasm = Some("wasm32-unknown-unknown".to_string());
+
+        // --wasm takes precedence over --target <TRIPLE>
+        let target = if cmd.is_wasm { &wasm } else { &cmd.target };
+
+        // Dynamic linking breaks release builds and doesn't work for WASM
+        let features = if cmd.is_release || cmd.is_wasm {
+            &None
+        } else {
+            &Some("bevy/dynamic")
+        };
+
+        args.add_opt_value("--package", &cmd.package)
+            .add_flag("--workspace", cmd.is_workspace)
+            .add_opt_value("--exclude", &cmd.exclude)
+            .add_flag("--lib", cmd.is_lib)
+            .add_flag("--locked", cmd.is_locked)
+            .add_opt_value("--bin", &cmd.bin)
+            .add_flag("--bins", cmd.is_bins)
+            .add_opt_value("--example", &cmd.example)
+            .add_flag("--examples", cmd.is_examples)
+            .add_opt_value("--test", &cmd.test)
+            .add_flag("--tests", cmd.is_tests)
+            .add_opt_value("--bench", &cmd.bench)
+            .add_flag("--benches", cmd.is_benches)
+            .add_flag("--all-targets", cmd.is_all_targets)
+            .add_flag("--release", cmd.is_release)
+            .add_opt_value("--target", target)
+            .add_opt_value("--target-dir", &cmd.target_dir)
+            .add_opt_value("--manifest-path", &cmd.manifest_path)
+            .add_opt_value("--features", features);
+
+        args
+    }
+}

--- a/src/check/cli.rs
+++ b/src/check/cli.rs
@@ -1,0 +1,90 @@
+use clap::{ArgAction, Args};
+
+use crate::cli::Command;
+
+use super::check;
+
+#[derive(Debug, Args)]
+pub struct CheckCommand {
+    /// Package to build (see `cargo help pkgid`).
+    #[clap(short = 'p', long = "package", value_name = "SPEC")]
+    pub package: Option<String>,
+
+    /// Build all packages in the workspace.
+    #[clap(long = "workspace", action = ArgAction::SetTrue, default_value_t = false)]
+    pub is_workspace: bool,
+
+    ///  Exclude packages from the build.
+    #[clap(long = "exclude", value_name = "SPEC")]
+    pub exclude: Option<String>,
+
+    /// Build only this package's library.
+    #[clap(long = "lib", action = ArgAction::SetTrue, default_value_t = false)]
+    pub is_lib: bool,
+
+    /// Require Cargo.lock is up to date.
+    #[clap(long = "locked", action = ArgAction::SetTrue, default_value_t = false)]
+    pub is_locked: bool,
+
+    /// Build only the specified binary.
+    #[clap(long = "bin", value_name = "NAME")]
+    pub bin: Option<String>,
+
+    /// Build all binaries.
+    #[clap(long = "bins", action = ArgAction::SetTrue, default_value_t = false)]
+    pub is_bins: bool,
+
+    /// Build only the specified example.
+    #[clap(long = "example", value_name = "NAME")]
+    pub example: Option<String>,
+
+    /// Build all examples.
+    #[clap(long = "examples", action = ArgAction::SetTrue, default_value_t = false)]
+    pub is_examples: bool,
+
+    /// Build only the specified test target.
+    #[clap(long = "test", value_name = "NAME")]
+    pub test: Option<String>,
+
+    /// Build all tests.
+    #[clap(long = "tests", action = ArgAction::SetTrue, default_value_t = false)]
+    pub is_tests: bool,
+
+    /// Build only the specified bench target.
+    #[clap(long = "bench", value_name = "NAME")]
+    pub bench: Option<String>,
+
+    /// Build all benches.
+    #[clap(long = "benches", action = ArgAction::SetTrue, default_value_t = false)]
+    pub is_benches: bool,
+
+    /// Build all benches.
+    #[clap(long = "all-targets", action = ArgAction::SetTrue, default_value_t = false)]
+    pub is_all_targets: bool,
+
+    /// Build artifacts in release mode, with optimizations.
+    #[clap(short = 'r', long = "release", action = ArgAction::SetTrue, default_value_t = false)]
+    pub is_release: bool,
+
+    /// Build for the target triple.
+    #[clap(long = "target", value_name = "TRIPLE")]
+    pub target: Option<String>,
+
+    /// Directory for all generated artifacts.
+    #[clap(long = "target-dir", value_name = "DIRECTORY")]
+    pub target_dir: Option<String>,
+
+    /// Path to Cargo.toml.
+    #[clap(long = "manifest-path", value_name = "PATH")]
+    pub manifest_path: Option<String>,
+
+    /// Build the game for the browser.
+    #[clap(short = 'w', long = "wasm", action = ArgAction::SetTrue, default_value_t = false)]
+    pub is_wasm: bool,
+}
+
+impl Command for CheckCommand {
+    fn exec(&self) {
+        check(self);
+    }
+}

--- a/src/check/mod.rs
+++ b/src/check/mod.rs
@@ -1,0 +1,6 @@
+use self::cli::CheckCommand;
+
+mod args;
+pub mod cli;
+
+pub fn check(args: &CheckCommand) {}

--- a/src/check/mod.rs
+++ b/src/check/mod.rs
@@ -1,6 +1,23 @@
-use self::cli::CheckCommand;
-
 mod args;
 pub mod cli;
 
-pub fn check(args: &CheckCommand) {}
+use crate::{
+    cargo::{cargo_check, ArgBuilder},
+    rustup::install_target_if_needed,
+};
+
+use self::cli::CheckCommand;
+
+pub fn check(args: &CheckCommand) {
+    if args.is_wasm {
+        // Make sure that all tools are set up correctly
+
+        // `wasm32-unknown-unknown` compilation target
+        install_target_if_needed("wasm32-unknown-unknown", true, false)
+            .expect("Installation of compilation target `wasm32-unknown-unknown` failed.");
+    }
+
+    let cargo_args = ArgBuilder::from(args);
+
+    cargo_check(cargo_args);
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,8 @@
 use clap::{Args, Parser, Subcommand};
 
-use crate::{build::cli::BuildCommand, new::cli::NewCommand, run::cli::RunCommand};
+use crate::{
+    build::cli::BuildCommand, check::cli::CheckCommand, new::cli::NewCommand, run::cli::RunCommand,
+};
 
 pub trait Command {
     /// Execute the command
@@ -50,18 +52,21 @@ impl Command for BavyCommand {
 enum BavySubcommand {
     /// Create a new Bevy app.
     New(NewCommand),
-    /// Run your Bevy app with optimized compile times.
-    Run(RunCommand),
+    /// Check your Bevy app with optimized compile times.
+    Check(CheckCommand),
     /// Build your Bevy app with optimized compile times.
     Build(BuildCommand),
+    /// Run your Bevy app with optimized compile times.
+    Run(RunCommand),
 }
 
 impl Command for BavySubcommand {
     fn exec(&self) {
         match self {
             BavySubcommand::New(cmd) => cmd.exec(),
-            BavySubcommand::Run(cmd) => cmd.exec(),
+            BavySubcommand::Check(cmd) => cmd.exec(),
             BavySubcommand::Build(cmd) => cmd.exec(),
+            BavySubcommand::Run(cmd) => cmd.exec(),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,6 @@
-use clap::Parser;
-use cli::{CargoCommand, Command};
-
 mod build;
 pub(crate) mod cargo;
+mod check;
 mod cli;
 pub(crate) mod env;
 pub(crate) mod files;
@@ -11,6 +9,9 @@ mod new;
 mod run;
 pub(crate) mod rustup;
 pub(crate) mod wasm_bindgen;
+
+use clap::Parser;
+use cli::{CargoCommand, Command};
 
 fn main() {
     let cmd = CargoCommand::parse();


### PR DESCRIPTION
Closes #6.

Adds a new `cargo bavy check` command that works similar to its `cargo` counterpart, but automatically passes `--features bevy/dynamic` in debug mode, for faster compile times.
It also has a `--wasm` flag to quickly check for the web.