### PR TITLE
Add missing GitHub token to Clippy CI workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - Fixed optimized dependency configuration having invalid table keys in `Cargo.toml`.
 - Fixed fast linker configuration including a shared generics flag on stable toolchain, which caused a compile error.
+- Fixed Clippy CI workflow not including GitHub token, so it wouldn't post comments with the warnings on your PRs.
 
 ## Release v0.1.0 - 2022-08-19
 

--- a/assets/.github/workflows/ci.yaml
+++ b/assets/.github/workflows/ci.yaml
@@ -69,6 +69,7 @@ jobs:
       - name: Run clippy
         uses: actions-rs/clippy-check@v1
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           args: -- -D warnings
 
   # Run cargo fmt --all -- --check


### PR DESCRIPTION
Fixes #15.

This properly passes the GitHub token to the Clippy CI workflow.
This allows the workflow to comment Clippy warnings on your PRs.

I previously thought the token wasn't needed, but it was.