### PR TITLE
Install wasm tools with `cargo bavy new`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,13 @@
   - They automatically add `--features bevy/dynamic` in debug mode for faster compile times.
   - They have an additional `--wasm`/`-w` flag to target the browser.
   - All necessary tools will be installed for you if needed.
-- A `.gitignore` file will now be added to the `wasm/` folder.
+- Changed `cargo bavy new` to add `.gitignore` file to the `wasm/` folder with the WASM option.
+- Changed `cargo bavy new` to automatically install needed tools when WASM option is selected.
+
+### Usability
+
+- Changed `cargo bavy new` to colorize output.
+- Changed `cargo bavy new` to suggest running `cargo bavy run` instead of `cargo run`.
 
 ### Bug fixes
 

--- a/src/new/bevy_features/mod.rs
+++ b/src/new/bevy_features/mod.rs
@@ -1,3 +1,5 @@
+use dialoguer::console::style;
+
 use super::{feature::Feature, utils::select_features};
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -26,5 +28,9 @@ impl ToString for BevyFeature {
 }
 
 pub fn select_bevy_features() -> Vec<BevyFeature> {
-    select_features("[1/3] Which Bevy features do you want?")
+    select_features(format!(
+        "{} Which {} do you want?",
+        style("[1/3]").black(),
+        style("Bevy features").cyan(),
+    ))
 }

--- a/src/new/compile_features/mod.rs
+++ b/src/new/compile_features/mod.rs
@@ -3,6 +3,8 @@ mod fast_linker;
 mod nightly;
 mod wasm;
 
+use dialoguer::console::style;
+
 use self::{
     dependencies::optimize_dependencies, fast_linker::add_fast_linker,
     nightly::add_nightly_toolchain, wasm::add_wasm,
@@ -49,7 +51,11 @@ impl ToString for CompileFeature {
 }
 
 pub fn select_compile_features() -> Vec<CompileFeature> {
-    select_features("[2/3] Which compile features do you want?")
+    select_features(format!(
+        "{} Which {} do you want?",
+        style("[2/3]").black(),
+        style("compile features").cyan(),
+    ))
 }
 
 pub fn register_compile_features(context: &mut Context) {

--- a/src/new/compile_features/wasm.rs
+++ b/src/new/compile_features/wasm.rs
@@ -1,4 +1,8 @@
-use crate::new::context::{Context, CreateFile};
+use crate::{
+    new::context::{Context, CreateFile},
+    rustup::install_target_if_needed,
+    wasm_bindgen::install_wasm_bindgen_if_needed,
+};
 
 pub fn add_wasm(context: &mut Context) {
     let wasm_index = include_str!(concat!(
@@ -17,4 +21,12 @@ pub fn add_wasm(context: &mut Context) {
     context
         .create_files
         .push(CreateFile::new("/wasm/.gitignore", wasm_gitignore));
+
+    context.extra_changes.push(Box::new(|_| {
+        install_target_if_needed("wasm32-unknown-unknown", false, true)
+            .expect("Failed to install `wasm32-unknown-unknown` target.");
+    }));
+    context.extra_changes.push(Box::new(|_| {
+        install_wasm_bindgen_if_needed(false, true).expect("Failed to install `wasm-bindgen-cli`.");
+    }));
 }

--- a/src/new/mod.rs
+++ b/src/new/mod.rs
@@ -60,7 +60,7 @@ fn create_bevy_app(mut context: Context) {
     );
     println!("\nNext steps:");
     println!("$ cd {folder_name}");
-    println!("$ cargo run");
+    println!("$ cargo bavy run");
 }
 
 fn create_cargo_app(context: &mut Context) {

--- a/src/new/mod.rs
+++ b/src/new/mod.rs
@@ -8,6 +8,8 @@ mod utils;
 
 use std::process::Command;
 
+use dialoguer::console::style;
+
 use crate::files::create_file_with_content;
 
 use self::{
@@ -19,9 +21,16 @@ use self::{
 };
 
 pub fn new(folder_name: &str) {
-    println!("Creating Bevy app `{folder_name}`...\n");
-    println!("- Use [Space] to select/unselect options");
-    println!("- Use [Enter] to confirm selection\n");
+    println!(
+        "{} Bevy app `{}`...\n",
+        style("Creating").green().bold(),
+        style(folder_name).cyan()
+    );
+    println!(
+        "- Use {} to select/unselect options",
+        style("[Space]").blue()
+    );
+    println!("- Use {} to confirm selection\n", style("[Enter]").blue());
 
     let mut context = Context::new(folder_name);
     context.bevy_features = select_bevy_features();
@@ -44,7 +53,11 @@ fn create_bevy_app(mut context: Context) {
     adjust_main_file(&mut context);
     apply_extra_changes(context);
 
-    println!("\nCreated Bevy app `{folder_name}`!");
+    println!(
+        "\n{} Bevy app `{}`!",
+        style("Created").green().bold(),
+        style(&folder_name).cyan()
+    );
     println!("\nNext steps:");
     println!("$ cd {folder_name}");
     println!("$ cargo run");

--- a/src/new/project_features/mod.rs
+++ b/src/new/project_features/mod.rs
@@ -7,6 +7,7 @@ use self::{
 };
 
 use super::{context::Context, feature::Feature, utils::select_features};
+use dialoguer::console::style;
 use license::get_copyright_info;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -48,7 +49,11 @@ impl ToString for ProjectFeature {
 }
 
 pub fn select_project_features() -> Vec<ProjectFeature> {
-    select_features("[3/3] Which project features do you want?")
+    select_features(format!(
+        "{} Which {} do you want?",
+        style("[3/3]").black(),
+        style("project features").cyan(),
+    ))
 }
 
 pub fn register_project_features(context: &mut Context) {

--- a/src/new/utils.rs
+++ b/src/new/utils.rs
@@ -31,11 +31,12 @@ pub fn add_dependency(folder_name: &str, name: &str, features: Vec<String>) {
     }
 }
 
-pub fn select_features<F>(prompt: &str) -> Vec<F>
+pub fn select_features<P, F>(prompt: P) -> Vec<F>
 where
+    P: Into<String>,
     F: Feature,
 {
-    println!("{prompt}");
+    println!("{}", prompt.into());
 
     let features = F::all();
     let selection = MultiSelect::new()


### PR DESCRIPTION
Closes #14.

`cargo bavy new` will now automatically install missing WASM tools if the WASM option has been selected.

The `cargo bavy new` output is now also colorized and suggests using `cargo bavy run` instead of `cargo run`.