### PR TITLE
Add option to configure Rust Analyzer to use `bevy/dynamic` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
   - All necessary tools will be installed for you if needed.
 - Changed `cargo bavy new` to add `.gitignore` file to the `wasm/` folder with the WASM option.
 - Changed `cargo bavy new` to automatically install needed tools when WASM option is selected.
+- Added option to `cargo bavy new` to configure Rust Analyzer in VS Code to use `bevy/dynamic` feature.
+  - This avoids unnecessary re-compiles after you use `cargo bavy run` and other commands.
+  - You should configure this for all projects where you use `cargo-bavy`.
 
 ### Usability
 

--- a/assets/.vscode/settings.json
+++ b/assets/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "rust-analyzer.cargo.features": ["bevy/dynamic"]
+}

--- a/src/new/compile_features/mod.rs
+++ b/src/new/compile_features/mod.rs
@@ -1,13 +1,15 @@
 mod dependencies;
 mod fast_linker;
 mod nightly;
+mod rust_analyzer_bevy_dynamic;
 mod wasm;
 
 use dialoguer::console::style;
 
 use self::{
     dependencies::optimize_dependencies, fast_linker::add_fast_linker,
-    nightly::add_nightly_toolchain, wasm::add_wasm,
+    nightly::add_nightly_toolchain,
+    rust_analyzer_bevy_dynamic::enable_bevy_dynamic_for_rust_analyzer, wasm::add_wasm,
 };
 
 use super::{context::Context, feature::Feature, utils::select_features};
@@ -18,6 +20,7 @@ pub enum CompileFeature {
     FastLinker,
     OptimizeDependencies,
     WasmTarget,
+    RustAnalyzerBevyDynamic,
 }
 
 impl Feature for CompileFeature {
@@ -28,6 +31,7 @@ impl Feature for CompileFeature {
             CompileFeature::FastLinker,
             CompileFeature::OptimizeDependencies,
             CompileFeature::WasmTarget,
+            CompileFeature::RustAnalyzerBevyDynamic,
         ]
     }
 
@@ -45,7 +49,12 @@ impl ToString for CompileFeature {
             CompileFeature::OptimizeDependencies => {
                 "Optimize dependencies in debug mode".to_string()
             }
-            CompileFeature::WasmTarget => "Target WASM".to_string(),
+            CompileFeature::WasmTarget => {
+                "Target WASM with `wasm32-unknown-unknown` and `wasm-bindgen-cli`".to_string()
+            }
+            CompileFeature::RustAnalyzerBevyDynamic => {
+                "Enable `bevy/dynamic` in VS Code for Rust Analyzer (faster compiles)".to_string()
+            }
         }
     }
 }
@@ -85,5 +94,12 @@ pub fn register_compile_features(context: &mut Context) {
         .contains(&CompileFeature::OptimizeDependencies)
     {
         optimize_dependencies(context);
+    }
+
+    if context
+        .compile_features
+        .contains(&CompileFeature::RustAnalyzerBevyDynamic)
+    {
+        enable_bevy_dynamic_for_rust_analyzer(context);
     }
 }

--- a/src/new/compile_features/rust_analyzer_bevy_dynamic.rs
+++ b/src/new/compile_features/rust_analyzer_bevy_dynamic.rs
@@ -1,0 +1,16 @@
+use crate::new::context::{Context, CreateFile};
+
+/// Enables the feature `bevy/dynamic` for Rust Analyzer.
+///
+/// This gives faster compiles and prevents Rust Analyzer checks from clashing
+/// with `cargo bavy` commands.
+pub fn enable_bevy_dynamic_for_rust_analyzer(context: &mut Context) {
+    let vscode_settings = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/assets/.vscode/settings.json"
+    ));
+
+    context
+        .create_files
+        .push(CreateFile::new("/.vscode/settings.json", vscode_settings));
+}


### PR DESCRIPTION
Closes #19.

`cargo bavy new` now provides an option to configure Rust Analyzer in VS Code to use the `bevy/dynamic` feature.

This reduces compile times and avoids unnecessary re-compilations when you use `cargo bavy` commands.
It should be enabled on all projects where you use `cargo bavy`.