### PR TITLE
Add bevy version 0.9 specifically

### DIFF
--- a/src/new/mod.rs
+++ b/src/new/mod.rs
@@ -84,7 +84,7 @@ fn create_files(context: &mut Context) {
 
 fn add_dependencies(context: &mut Context) {
     context.add_dependencies.push(AddDependency {
-        name: "bevy".to_string(),
+        name: "bevy@0.9".to_string(),
         features: vec![],
     });
 

--- a/src/rustup.rs
+++ b/src/rustup.rs
@@ -32,8 +32,7 @@ pub fn install_target_if_needed(target: &str, ask_user: bool, hidden: bool) -> R
     if ask_user
         && !Confirm::new()
             .with_prompt(format!(
-                "Compilation target `{}` is missing, should I install it for you?",
-                target
+                "Compilation target `{target}` is missing, should I install it for you?",
             ))
             .interact()
             .unwrap()


### PR DESCRIPTION
Closes #28.

Instead of executing `cargo add bevy`, the `bavy new` command will now use `cargo add bevy@0.9`.
This enables us to fix the code templates for `0.10` before users create new projects that might not compile.